### PR TITLE
Open file in binary mode for Python3

### DIFF
--- a/lastrun/__init__.py
+++ b/lastrun/__init__.py
@@ -14,7 +14,7 @@ def when():
 
 
 def record():
-    with open('.lastrun', 'w') as f:
+    with open('.lastrun', 'wb') as f:
         now = datetime.datetime.now()
         pickle.dump(now, f)
         return now


### PR DESCRIPTION
Open the file in binary mode wich resolves "TypeError: must be str, not bytes" error in Python 3
